### PR TITLE
Update README.md to emphasize build directory location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Just want to use it? You can [install a pre-packaged version from Chrome Web Sto
 npm install
 gulp
 ````
-And load up the build directory as a chrome extenstion. [Need help?](https://developer.chrome.com/apps/first_app#five)
+And load up the `build/` directory as a chrome extenstion. [Need help?](https://developer.chrome.com/apps/first_app#five)
 


### PR DESCRIPTION
I somehow managed to misread this line and imported the root directory rather than the build one—which actually mostly appeared to work, but had the error `ui.js:1 Uncaught ReferenceError: require is not defined` (of course, since this was loading the pre-build `index.html`, etc.).

This proposed change might make someone slightly less likely to make that mistake, I hope! :)
